### PR TITLE
[Fix] Corrigindo Busca de Atributos Protegidos

### DIFF
--- a/src/Exceptions/ProblemDetailException.php
+++ b/src/Exceptions/ProblemDetailException.php
@@ -58,14 +58,15 @@ abstract class ProblemDetailException extends Exception
             ExceptionsFieldsEnum::MESSAGE->value           => $this->message,
             ExceptionsFieldsEnum::USER_MESSAGE->value      => $this->userMessage,
             ExceptionsFieldsEnum::USER_TITLE->value        => $this->userTitle,
-            ExceptionsFieldsEnum::LOCATION->value          => $this->file . ':' . $this->line,
+            ExceptionsFieldsEnum::LOCATION->value          => ($this->getFile() . ':' . $this->getLine()),
             ExceptionsFieldsEnum::TRACE_ID->value          => data_get(Log::sharedContext(), 'trace_id'),
             ExceptionsFieldsEnum::PREVIOUS_MESSAGE->value  => $this->previous->getMessage() ?? null,
             ExceptionsFieldsEnum::PREVIOUS_TYPE->value     => $this->previous::class ?? null,
             ExceptionsFieldsEnum::PREVIOUS_CODE->value     => $this->previous->getCode() ?? null,
-            ExceptionsFieldsEnum::PREVIOUS_LOCATION->value => $this->previous->file . ':' . $this->previous->line ??
-                null,
+            ExceptionsFieldsEnum::PREVIOUS_LOCATION->value => ($this->previous->getFile() . ':' .
+                    $this->previous->getLine()) ?? null,
         ];
+
 
         return array_filter(
             $allFields,


### PR DESCRIPTION
## Descrição
Foi feita uma correção para corrigir a busca dos atributos file e code de uma exception prévia enviada para dentro do ProblemDetailException

Esse acesso estava sendo feito sem um método get, e isso quebrou o código! 
